### PR TITLE
Add lines in main.py and config.py to handle TIFFs over 4GB

### DIFF
--- a/odyn/config.py
+++ b/odyn/config.py
@@ -54,6 +54,8 @@ def create_config(path: str | Path) -> None:
 
     # Get metadata from the first raw TIFF file
     tif = TiffFile(file_paths[0])
+    size_gb = file_paths[0].stat().st_size / 1000000000
+    config["metadata"]["size_gigabytes"] = size_gb
     SI_metadata = tif.scanimage_metadata["FrameData"]
     width_px, height_px = tif.pages[0].shape
 

--- a/odyn/main.py
+++ b/odyn/main.py
@@ -180,7 +180,12 @@ class Experiment:
 
         # If final save settings and TIFF files
         if final:
-            print("[INFO] Saving mcor files...")
+            if self.config["metadata"]["size_gigabytes"] > 4:
+                big_file = True
+                print("[INFO] Saving mcor files with bigtiff = True...")
+            else:
+                big_file = False
+                print("[INFO] Saving mcor files...")
 
             # Record settings in the motion_correction section
             temp = dict(test_config)

--- a/odyn/main.py
+++ b/odyn/main.py
@@ -204,7 +204,7 @@ class Experiment:
                 mc = cm.load(mmap_path)
 
                 # Saving TIFFs directly because caiman saves them as 64-bit
-                with tifffile.TiffWriter(mcor_path) as tif:
+                with tifffile.TiffWriter(mcor_path, bigtiff = big_file) as tif:
                     tif.write(
                         [mc[i].copy() for i in range(mc.shape[0])],
                         shape=mc[0].shape,

--- a/odyn/odyn_config.toml
+++ b/odyn/odyn_config.toml
@@ -35,7 +35,7 @@ frames = 100                   # A - How many frames in each TIFF stack
 size_pixels = [100, 100]       # A - Size of each frame in pixels
 size_ums = [100, 100]          # A - Size of each frame in micrometers
 um_per_pixels = [0.0, 0.0]     # A - Conversion rate
-
+size_gigabytes = 10
 
 # Test Motion Correction Settings ----------------------------------------------------- #
 # Settings used when processing subsets of the data or when doing quick checks.


### PR DESCRIPTION
goal: to write motion-corrected TIFF files over 4GB
with changes, file size of the first TIFF is found & displayed with other 1st TIFF metadata in the .toml file. when tifffile writes the mcor movies, if the first TIFF is over 4GB it will automatically write the movies with the parameter bigtiff set to True